### PR TITLE
[hand2eye] implement manual and auto calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ The following attribute template can be used to configure this model:
   "pose_tracker": <string>,
   "motion": <string>,
   "sleep_seconds": <float>,
-  "use_motion_service_for_poses": <bool>
+  "use_motion_service_for_poses": <bool>,
+  "camera_frame_parent": <string>
 }
 ```
 
@@ -225,13 +226,20 @@ The following attributes are available for this model:
 | `sleep_seconds`   | `float`  | `Optional`  | Sleep time between movements to allow the arm to settle (defaults to 2.0 seconds). |
 | `use_motion_service_for_poses` | `bool` | `Optional` | Use `motion.get_pose()` (with the arm's origin frame) instead of `arm.get_end_position()` to read the achieved end-effector pose. Defaults to false. Requires `motion` when true. |
 | `body_name`       | `string` | `Optional`  | Name of the specific tracked body to use (e.g., AprilTag ID like `"tag36h11:0"` or chessboard corner like `"corner_0"`). Calibration expects exactly one tracked pose; set this when the pose tracker returns multiple. **Important**: when using chessboard corners, ensure the board's orientation is stable across all poses so the same corner is tracked. |
+| `camera_frame_parent` | `string` | `Optional` | Eye-to-hand only: the frame the returned camera frame is parented to (defaults to `"world"`). The solved transform is the camera pose in the **arm base** frame, so this should be the frame the arm base is mounted in — see *Calibration types* below. |
 
 **Note**: in `pose_selection="manual"` mode, either `joint_positions` or `poses` must be provided. In `pose_selection="auto"` mode, both are ignored and `pose_sampling` is required.
 
 Available calibrations are:
 
-- "eye-in-hand"
-- "eye-to-hand" *(not yet implemented end-to-end; the new corner-based solvers and auto sampler currently assume eye-in-hand)*
+- **"eye-in-hand"** — the camera rides the gripper and looks at a target fixed in the world. The result is the camera pose relative to the gripper; the returned `frame` is parented to the arm (`parent: <arm_name>`) so it can be pasted into the camera component's frame config as a child of the arm.
+- **"eye-to-hand"** — the camera is statically mounted and watches a target rigidly held by the gripper (or bolted to it). The result is the camera pose in the **arm base** frame; the returned `frame` is parented to `camera_frame_parent` (default `"world"`) so it can be pasted into the fixed camera component's frame config. **Caveat**: the solved transform is camera-in-arm-base. If your arm's own frame places its base anywhere other than the identity pose of `camera_frame_parent`, compose the returned transform with the arm's frame (or parent the camera to the same frame the arm is parented to and apply the arm's offset) before pasting.
+
+Both types run the same data-collection procedure and support all solvers, both pose-selection modes, and partially visible ChArUco boards. For eye-to-hand specifically:
+
+- Hold the board in one rigid grasp for the entire run — any slip or regrasp invalidates subsequent measurements. The board-in-gripper transform is solved internally as a nuisance parameter; you never need to measure it.
+- The gripper occluding part of the ChArUco board is fine (use the `viam:opencv:charuco` tracker); keep the visible corners well spread rather than clustered.
+- In auto pose-selection mode, set `look_at_point` to the static **camera's** location and mount the board facing outward along the tool +Z, so sampled poses aim the board at the camera.
 
 Available methods are:
 
@@ -258,7 +266,7 @@ After moving to each candidate the service captures the calibration measurement 
 | Field                          | Type    | Required | Description |
 |--------------------------------|---------|----------|-------------|
 | `workspace_bounds.x.min/max`   | float   | yes      | Sampling range for end-effector position along base-frame X, in mm. (Likewise `y`, `z`.) |
-| `look_at_point`                | `[x,y,z]` | yes    | Chessboard center in robot base frame, in mm. Easiest way to find: touch the board with the TCP and read `arm.get_end_position()`. |
+| `look_at_point`                | `[x,y,z]` | yes    | The point the tool +Z aims at, in robot base frame, in mm. Eye-in-hand: the chessboard center (easiest way to find: touch the board with the TCP and read `arm.get_end_position()`). Eye-to-hand: the static camera's approximate location. |
 | `n_poses`                      | int     | no       | Number of successful poses to collect. Defaults to 20. |
 | `max_attempts`                 | int     | no       | Cap on total sample attempts (including skips). Defaults to 60. |
 | `roll_range_deg`               | `[lo, hi]` | no    | Range for the random roll about the optical axis, in degrees. Defaults to `[-180, 180]`. |
@@ -374,13 +382,41 @@ The response gains a `refinement` block with `rmse_pixels`, `per_pose_rmse_pixel
 
 No `joint_positions` or `poses` are needed in auto mode. The response includes an `auto_sampling` block reporting `requested_n_poses` vs `captured_n_poses`.
 
+**Eye-to-hand (static camera, board held by the gripper):**
+
+```json
+{
+  "arm_name": "my_arm",
+  "calibration_type": "eye-to-hand",
+  "camera_frame_parent": "world",
+  "method": "CALIB_HAND_EYE_TSAI",
+  "solver": "hybrid",
+  "pose_tracker": "charuco_tracker",
+  "motion": "motion",
+  "pose_selection": "auto",
+  "pose_sampling": {
+    "workspace_bounds": {
+      "x": {"min": 200, "max": 450},
+      "y": {"min": -150, "max": 150},
+      "z": {"min": 200, "max": 450}
+    },
+    "look_at_point": [700, 0, 300],
+    "n_poses": 15,
+    "max_attempts": 80,
+    "roll_range_deg": [-60, 60]
+  }
+}
+```
+
+Here `look_at_point` is the fixed camera's approximate position in the arm base frame, so sampled poses aim the gripper-held board at the camera. The returned `frame` is the camera's pose parented to `world` — paste it directly into the fixed camera component's frame config.
+
 ### Available Commands
 
 The hand-eye calibration service provides the following commands via `do_command`:
 
 #### `run_calibration`
 
-Runs the hand-eye calibration procedure. In manual mode, moves the arm through all configured positions; in auto mode, samples and visits poses until `n_poses` reachable observations are collected. Then runs the chosen `solver` and computes the camera-to-gripper transformation.
+Runs the hand-eye calibration procedure. In manual mode, moves the arm through all configured positions; in auto mode, samples and visits poses until `n_poses` reachable observations are collected. Then runs the chosen `solver` and computes the camera transform: camera-in-gripper for eye-in-hand, camera-in-arm-base for eye-to-hand.
 
 **Example:**
 
@@ -392,9 +428,10 @@ result = await hand_eye_service.do_command({"run_calibration": True})
 
 | Key             | Present when      | Contents |
 |-----------------|-------------------|----------|
-| `frame`         | always            | Frame-system-compatible transform (`translation`, `orientation`, `parent`). |
-| `residuals`     | always            | Per-pose translation/rotation residuals against the mean board pose in base frame, plus summary stats. Lets you spot outlier poses without re-running calibration. |
+| `frame`         | always            | Frame-system-compatible transform (`translation`, `orientation`, `parent`) — the camera's pose, ready to paste into the camera component's frame config. Eye-in-hand: parented to the arm. Eye-to-hand: parented to `camera_frame_parent` (default `"world"`). |
+| `residuals`     | always            | Per-pose translation/rotation residuals against the mean board pose (in base frame for eye-in-hand, in gripper frame for eye-to-hand — the constant of each arrangement), plus summary stats. Lets you spot outlier poses without re-running calibration. |
 | `solver`        | always            | The solver that ran (`"opencv"`, `"hybrid"`, or `"reprojection"`). |
+| `calibration_type` | always         | `"eye-in-hand"` or `"eye-to-hand"`. |
 | `refinement`    | `hybrid`/`reprojection` only | Reprojection solver diagnostics: `rmse_pixels`, `per_pose_rmse_pixels`, `iterations`, `success`, `message`. |
 | `auto_sampling` | `pose_selection="auto"` only | `requested_n_poses` and `captured_n_poses`. |
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The following attributes are available for this model:
 Available calibrations are:
 
 - **"eye-in-hand"** — the camera rides the gripper and looks at a target fixed in the world. The result is the camera pose relative to the gripper; the returned `frame` is parented to the arm (`parent: <arm_name>`) so it can be pasted into the camera component's frame config as a child of the arm.
-- **"eye-to-hand"** — the camera is statically mounted and watches a target rigidly held by the gripper (or bolted to it). The result is the camera pose in the **arm base** frame; the returned `frame` is parented to `"world"` so it can be pasted into the fixed camera component's frame config. **Caveat**: the solved transform is camera-in-arm-base. If your arm's own frame places its base anywhere other than the identity pose of `"world"`, compose the returned transform with the arm's frame (or parent the camera to the same frame the arm is parented to and apply the arm's offset) before pasting.
+- **"eye-to-hand"** — the camera is statically mounted and watches a target rigidly held by the gripper (or bolted to it). The result is the camera pose in the **arm's base frame** — the only static reference the calibration actually has, since the arm's TCP moves throughout the process. The returned `frame` is parented to `<arm_name>_origin` so it can be pasted into the fixed camera component's frame config as a child of that frame.
 
 Both types run the same data-collection procedure and support all solvers, both pose-selection modes, and partially visible ChArUco boards. For eye-to-hand specifically:
 
@@ -408,7 +408,7 @@ No `joint_positions` or `poses` are needed in auto mode. The response includes a
 }
 ```
 
-Here `look_at_point` is the fixed camera's approximate position in the arm base frame, and `charuco_target` is a frame already configured in the machine's frame system as a child of `my_arm` — with a pose describing however the board is actually mounted, and a box geometry sized to the board — so sampled poses aim the board (not necessarily the arm's own tool +Z) at the camera, and the motion service avoids colliding the board with anything else in the frame system while planning. The returned `frame` is the camera's pose parented to `world` — paste it directly into the fixed camera component's frame config.
+Here `look_at_point` is the fixed camera's approximate position in the arm base frame, and `charuco_target` is a frame already configured in the machine's frame system as a child of `my_arm` — with a pose describing however the board is actually mounted, and a box geometry sized to the board — so sampled poses aim the board (not necessarily the arm's own tool +Z) at the camera, and the motion service avoids colliding the board with anything else in the frame system while planning. The returned `frame` is the camera's pose parented to `my_arm_origin` (the arm's base frame) — paste it directly into the fixed camera component's frame config.
 
 `target` is required for `calibration_type="eye-to-hand"` with `pose_selection="auto"` — `validate_config` rejects the config without it, since auto-mode sampling needs a frame to move and to model collision geometry for the held target. (Manual mode doesn't need it — see the attribute table above.)
 
@@ -430,7 +430,7 @@ result = await hand_eye_service.do_command({"run_calibration": True})
 
 | Key             | Present when      | Contents |
 |-----------------|-------------------|----------|
-| `frame`         | always            | Frame-system-compatible transform (`translation`, `orientation`, `parent`) — the camera's pose, ready to paste into the camera component's frame config. Eye-in-hand: parented to the arm. Eye-to-hand: parented to `"world"`. |
+| `frame`         | always            | Frame-system-compatible transform (`translation`, `orientation`, `parent`) — the camera's pose, ready to paste into the camera component's frame config. Eye-in-hand: parented to the arm's TCP. Eye-to-hand: parented to the arm's base frame (`<arm_name>_origin`), not its TCP. |
 | `residuals`     | always            | Per-pose translation/rotation residuals against the mean board pose (in base frame for eye-in-hand, in gripper frame for eye-to-hand — the constant of each arrangement), plus summary stats. Lets you spot outlier poses without re-running calibration. |
 | `solver`        | always            | The solver that ran (`"opencv"`, `"hybrid"`, or `"reprojection"`). |
 | `calibration_type` | always         | `"eye-in-hand"` or `"eye-to-hand"`. |

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ The following attribute template can be used to configure this model:
   "motion": <string>,
   "sleep_seconds": <float>,
   "use_motion_service_for_poses": <bool>,
-  "camera_frame_parent": <string>,
   "target": <string>
 }
 ```
@@ -227,15 +226,14 @@ The following attributes are available for this model:
 | `sleep_seconds`   | `float`  | `Optional`  | Sleep time between movements to allow the arm to settle (defaults to 2.0 seconds). |
 | `use_motion_service_for_poses` | `bool` | `Optional` | Use `motion.get_pose()` (with the arm's origin frame) instead of `arm.get_end_position()` to read the achieved end-effector pose. Defaults to false. Requires `motion` when true. |
 | `body_name`       | `string` | `Optional`  | Name of the specific tracked body to use (e.g., AprilTag ID like `"tag36h11:0"` or chessboard corner like `"corner_0"`). Calibration expects exactly one tracked pose; set this when the pose tracker returns multiple. **Important**: when using chessboard corners, ensure the board's orientation is stable across all poses so the same corner is tracked. |
-| `camera_frame_parent` | `string` | `Optional` | Eye-to-hand only: the frame the returned camera frame is parented to (defaults to `"world"`). The solved transform is the camera pose in the **arm base** frame, so this should be the frame the arm base is mounted in — see *Calibration types* below. |
-| `target`          | `string` | `Required***` | Eye-to-hand only (rejected for eye-in-hand configs, preserving today's eye-in-hand behavior unchanged). **Required** when `calibration_type="eye-to-hand"` and `pose_selection="auto"`; not required (but harmless if set) in manual mode for either calibration type. Name of an existing frame or component, already configured in the machine's frame system as a child of the arm and carrying its own collision geometry, representing whatever's rigidly attached to the gripper and holding the calibration target (the ChArUco board itself, or a near-zero-volume frame if the target is just taped on, e.g. an AprilTag). Auto-mode sampling commands the motion service to move this frame instead of the arm directly; the motion service resolves the required arm motion from the already-configured frame-system relationship, and avoids collisions using the frame's geometry automatically. In manual mode it's simply unused for move commands — collision avoidance against the frame's geometry still happens automatically there too, independent of this attribute, as soon as the frame/geometry exists in the machine config. |
+| `target`          | `string` | `Required***` | Eye-to-hand only; required when `pose_selection="auto"` (not needed in manual mode). Name of an existing frame in the machine's frame system, parented under the arm with its own collision geometry, representing whatever holds the calibration target. See *Auto pose sampling* below. |
 
 **Note**: in `pose_selection="manual"` mode, either `joint_positions` or `poses` must be provided. In `pose_selection="auto"` mode, both are ignored and `pose_sampling` is required.
 
 Available calibrations are:
 
 - **"eye-in-hand"** — the camera rides the gripper and looks at a target fixed in the world. The result is the camera pose relative to the gripper; the returned `frame` is parented to the arm (`parent: <arm_name>`) so it can be pasted into the camera component's frame config as a child of the arm.
-- **"eye-to-hand"** — the camera is statically mounted and watches a target rigidly held by the gripper (or bolted to it). The result is the camera pose in the **arm base** frame; the returned `frame` is parented to `camera_frame_parent` (default `"world"`) so it can be pasted into the fixed camera component's frame config. **Caveat**: the solved transform is camera-in-arm-base. If your arm's own frame places its base anywhere other than the identity pose of `camera_frame_parent`, compose the returned transform with the arm's frame (or parent the camera to the same frame the arm is parented to and apply the arm's offset) before pasting.
+- **"eye-to-hand"** — the camera is statically mounted and watches a target rigidly held by the gripper (or bolted to it). The result is the camera pose in the **arm base** frame; the returned `frame` is parented to `"world"` so it can be pasted into the fixed camera component's frame config. **Caveat**: the solved transform is camera-in-arm-base. If your arm's own frame places its base anywhere other than the identity pose of `"world"`, compose the returned transform with the arm's frame (or parent the camera to the same frame the arm is parented to and apply the arm's offset) before pasting.
 
 Both types run the same data-collection procedure and support all solvers, both pose-selection modes, and partially visible ChArUco boards. For eye-to-hand specifically:
 
@@ -263,7 +261,7 @@ The roll randomization is what gives the resulting pose set good rotation-axis d
 
 After moving to each candidate the service captures the calibration measurement (arm pose + board observation) right there — sampling and data collection are a single pass, so the arm never re-visits poses. Unreachable poses, planning failures, and poses where the board is out of view are silently skipped and resampled, up to `max_attempts` total attempts.
 
-**Which frame gets moved**: normally the sampled pose is commanded directly to the arm's own end-effector, and the **assumption** is that whatever's attached (camera or board) faces roughly along the arm's own +Z with no offset. For eye-to-hand with `target` configured, the sampled pose is instead commanded to the `target` frame — the motion service resolves the arm motion needed to place that frame there, using the mount offset already described in the frame system, so the board can be held any way. Either way, if your mount (or `target`'s configured pose) is at a wild angle relative to the sampling geometry, you may need to widen `workspace_bounds` so enough candidates land with the target in the camera's view.
+**Which frame gets moved**: eye-in-hand (and eye-to-hand without `target`) commands the sampled pose directly to the arm's end-effector, assuming whatever's attached faces roughly along the arm's own +Z with no offset. Eye-to-hand with `target` configured instead commands the `target` frame — see the *Calibration types* section above. If the target ends up out of the camera's view more often than expected, widen `workspace_bounds`.
 
 | Field                          | Type    | Required | Description |
 |--------------------------------|---------|----------|-------------|
@@ -390,7 +388,6 @@ No `joint_positions` or `poses` are needed in auto mode. The response includes a
 {
   "arm_name": "my_arm",
   "calibration_type": "eye-to-hand",
-  "camera_frame_parent": "world",
   "target": "charuco_target",
   "method": "CALIB_HAND_EYE_TSAI",
   "solver": "hybrid",
@@ -433,7 +430,7 @@ result = await hand_eye_service.do_command({"run_calibration": True})
 
 | Key             | Present when      | Contents |
 |-----------------|-------------------|----------|
-| `frame`         | always            | Frame-system-compatible transform (`translation`, `orientation`, `parent`) — the camera's pose, ready to paste into the camera component's frame config. Eye-in-hand: parented to the arm. Eye-to-hand: parented to `camera_frame_parent` (default `"world"`). |
+| `frame`         | always            | Frame-system-compatible transform (`translation`, `orientation`, `parent`) — the camera's pose, ready to paste into the camera component's frame config. Eye-in-hand: parented to the arm. Eye-to-hand: parented to `"world"`. |
 | `residuals`     | always            | Per-pose translation/rotation residuals against the mean board pose (in base frame for eye-in-hand, in gripper frame for eye-to-hand — the constant of each arrangement), plus summary stats. Lets you spot outlier poses without re-running calibration. |
 | `solver`        | always            | The solver that ran (`"opencv"`, `"hybrid"`, or `"reprojection"`). |
 | `calibration_type` | always         | `"eye-in-hand"` or `"eye-to-hand"`. |

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ The following attribute template can be used to configure this model:
   "motion": <string>,
   "sleep_seconds": <float>,
   "use_motion_service_for_poses": <bool>,
-  "camera_frame_parent": <string>
+  "camera_frame_parent": <string>,
+  "target": <string>
 }
 ```
 
@@ -227,6 +228,7 @@ The following attributes are available for this model:
 | `use_motion_service_for_poses` | `bool` | `Optional` | Use `motion.get_pose()` (with the arm's origin frame) instead of `arm.get_end_position()` to read the achieved end-effector pose. Defaults to false. Requires `motion` when true. |
 | `body_name`       | `string` | `Optional`  | Name of the specific tracked body to use (e.g., AprilTag ID like `"tag36h11:0"` or chessboard corner like `"corner_0"`). Calibration expects exactly one tracked pose; set this when the pose tracker returns multiple. **Important**: when using chessboard corners, ensure the board's orientation is stable across all poses so the same corner is tracked. |
 | `camera_frame_parent` | `string` | `Optional` | Eye-to-hand only: the frame the returned camera frame is parented to (defaults to `"world"`). The solved transform is the camera pose in the **arm base** frame, so this should be the frame the arm base is mounted in — see *Calibration types* below. |
+| `target`          | `string` | `Required***` | Eye-to-hand only (rejected for eye-in-hand configs, preserving today's eye-in-hand behavior unchanged). **Required** when `calibration_type="eye-to-hand"` and `pose_selection="auto"`; not required (but harmless if set) in manual mode for either calibration type. Name of an existing frame or component, already configured in the machine's frame system as a child of the arm and carrying its own collision geometry, representing whatever's rigidly attached to the gripper and holding the calibration target (the ChArUco board itself, or a near-zero-volume frame if the target is just taped on, e.g. an AprilTag). Auto-mode sampling commands the motion service to move this frame instead of the arm directly; the motion service resolves the required arm motion from the already-configured frame-system relationship, and avoids collisions using the frame's geometry automatically. In manual mode it's simply unused for move commands — collision avoidance against the frame's geometry still happens automatically there too, independent of this attribute, as soon as the frame/geometry exists in the machine config. |
 
 **Note**: in `pose_selection="manual"` mode, either `joint_positions` or `poses` must be provided. In `pose_selection="auto"` mode, both are ignored and `pose_sampling` is required.
 
@@ -239,7 +241,7 @@ Both types run the same data-collection procedure and support all solvers, both 
 
 - Hold the board in one rigid grasp for the entire run — any slip or regrasp invalidates subsequent measurements. The board-in-gripper transform is solved internally as a nuisance parameter; you never need to measure it.
 - The gripper occluding part of the ChArUco board is fine (use the `viam:opencv:charuco` tracker); keep the visible corners well spread rather than clustered.
-- In auto pose-selection mode, set `look_at_point` to the static **camera's** location and mount the board facing outward along the tool +Z, so sampled poses aim the board at the camera.
+- In auto pose-selection mode, `target` is required and `look_at_point` should be set to the static **camera's** location: sampled poses aim `target`'s +Z at the camera and the motion service moves the arm to achieve it — the board can be held any way, since `target`'s pose in the frame system already describes how it's mounted.
 
 Available methods are:
 
@@ -254,19 +256,19 @@ Available methods are:
 When `pose_selection` is `"auto"`, the service randomly generates and visits poses inside a rectangular workspace volume. Each candidate has:
 
 - a position drawn uniformly from `workspace_bounds`,
-- an orientation that aims the end-effector's +Z axis at `look_at_point`,
+- an orientation that aims the sampled frame's +Z axis at `look_at_point`,
 - a random *roll* about that axis drawn from `roll_range_deg`.
 
 The roll randomization is what gives the resulting pose set good rotation-axis diversity. Pure look-at without roll would cluster rotation axes in a plane and produce ill-conditioned calibrations (see `compute_pose_diversity` below).
 
 After moving to each candidate the service captures the calibration measurement (arm pose + board observation) right there — sampling and data collection are a single pass, so the arm never re-visits poses. Unreachable poses, planning failures, and poses where the board is out of view are silently skipped and resampled, up to `max_attempts` total attempts.
 
-**Assumption**: the camera's optical axis is roughly aligned with the end-effector +Z. The chessboard tracker is forgiving as long as corners are in frame, but if your mount is at a wild angle you may need to widen `workspace_bounds` so enough candidates land with the target in view.
+**Which frame gets moved**: normally the sampled pose is commanded directly to the arm's own end-effector, and the **assumption** is that whatever's attached (camera or board) faces roughly along the arm's own +Z with no offset. For eye-to-hand with `target` configured, the sampled pose is instead commanded to the `target` frame — the motion service resolves the arm motion needed to place that frame there, using the mount offset already described in the frame system, so the board can be held any way. Either way, if your mount (or `target`'s configured pose) is at a wild angle relative to the sampling geometry, you may need to widen `workspace_bounds` so enough candidates land with the target in the camera's view.
 
 | Field                          | Type    | Required | Description |
 |--------------------------------|---------|----------|-------------|
-| `workspace_bounds.x.min/max`   | float   | yes      | Sampling range for end-effector position along base-frame X, in mm. (Likewise `y`, `z`.) |
-| `look_at_point`                | `[x,y,z]` | yes    | The point the tool +Z aims at, in robot base frame, in mm. Eye-in-hand: the chessboard center (easiest way to find: touch the board with the TCP and read `arm.get_end_position()`). Eye-to-hand: the static camera's approximate location. |
+| `workspace_bounds.x.min/max`   | float   | yes      | Sampling range for the moved frame's position along base-frame X, in mm. (Likewise `y`, `z`.) |
+| `look_at_point`                | `[x,y,z]` | yes    | The point the moved frame's +Z aims at, in robot base frame, in mm. Eye-in-hand: the chessboard center (easiest way to find: touch the board with the TCP and read `arm.get_end_position()`). Eye-to-hand: the static camera's approximate location. |
 | `n_poses`                      | int     | no       | Number of successful poses to collect. Defaults to 20. |
 | `max_attempts`                 | int     | no       | Cap on total sample attempts (including skips). Defaults to 60. |
 | `roll_range_deg`               | `[lo, hi]` | no    | Range for the random roll about the optical axis, in degrees. Defaults to `[-180, 180]`. |
@@ -389,6 +391,7 @@ No `joint_positions` or `poses` are needed in auto mode. The response includes a
   "arm_name": "my_arm",
   "calibration_type": "eye-to-hand",
   "camera_frame_parent": "world",
+  "target": "charuco_target",
   "method": "CALIB_HAND_EYE_TSAI",
   "solver": "hybrid",
   "pose_tracker": "charuco_tracker",
@@ -408,7 +411,9 @@ No `joint_positions` or `poses` are needed in auto mode. The response includes a
 }
 ```
 
-Here `look_at_point` is the fixed camera's approximate position in the arm base frame, so sampled poses aim the gripper-held board at the camera. The returned `frame` is the camera's pose parented to `world` — paste it directly into the fixed camera component's frame config.
+Here `look_at_point` is the fixed camera's approximate position in the arm base frame, and `charuco_target` is a frame already configured in the machine's frame system as a child of `my_arm` — with a pose describing however the board is actually mounted, and a box geometry sized to the board — so sampled poses aim the board (not necessarily the arm's own tool +Z) at the camera, and the motion service avoids colliding the board with anything else in the frame system while planning. The returned `frame` is the camera's pose parented to `world` — paste it directly into the fixed camera component's frame config.
+
+`target` is required for `calibration_type="eye-to-hand"` with `pose_selection="auto"` — `validate_config` rejects the config without it, since auto-mode sampling needs a frame to move and to model collision geometry for the held target. (Manual mode doesn't need it — see the attribute table above.)
 
 ### Available Commands
 
@@ -461,6 +466,8 @@ Returns a dict with `n_poses`, `n_pairs`, `mean_rotation_angle_deg`, `translatio
 #### `generate_poses`
 
 Standalone pose sampler — returns a list of poses without moving the arm. Same sampling logic as `pose_selection="auto"` but useful as a preview: paste the result into your `poses` config and run a manual calibration, or just sanity-check the diversity numbers before kicking off an auto run.
+
+**Caveat when `target` is configured**: this command samples poses in isolation and has no way to know about `target`. If you're previewing sampling parameters for a run that will use `target`, the returned poses represent poses for the `target` frame, not the arm — they are not directly paste-ready into manual-mode `poses` in that case, since manual mode always specifies arm poses.
 
 **Example:**
 

--- a/src/models/hand_eye_calibration.py
+++ b/src/models/hand_eye_calibration.py
@@ -30,7 +30,9 @@ except ModuleNotFoundError:
     from ..solvers.robust_init import robust_bootstrap_handeye
     from ..active_calibration.pose_sampler import generate_pose_set, sample_transform
 
-CALIBS = ["eye-in-hand", "eye-to-hand"]
+CALIB_EYE_IN_HAND = "eye-in-hand"
+CALIB_EYE_TO_HAND = "eye-to-hand"
+CALIBS = [CALIB_EYE_IN_HAND, CALIB_EYE_TO_HAND]
 METHODS = [
     "CALIB_HAND_EYE_TSAI",
     "CALIB_HAND_EYE_PARK",
@@ -55,6 +57,7 @@ SOLVER_ATTR = "solver"
 USE_MOTION_SERVICE_FOR_POSES_ATTR = "use_motion_service_for_poses"
 POSE_SELECTION_ATTR = "pose_selection"
 POSE_SAMPLING_ATTR = "pose_sampling"
+CAMERA_FRAME_PARENT_ATTR = "camera_frame_parent"
 
 # do_command keys a viam:opencv pose tracker exposes a raw observation under.
 # A chessboard reports the full grid every frame; a ChArUco board may report a
@@ -83,6 +86,7 @@ DEFAULT_METHOD = "CALIB_HAND_EYE_TSAI"
 DEFAULT_SOLVER = SOLVER_OPENCV
 DEFAULT_USE_MOTION_SERVICE_FOR_POSES = False
 DEFAULT_POSE_SELECTION = POSE_SELECTION_MANUAL
+DEFAULT_CAMERA_FRAME_PARENT = "world"
 DEFAULT_AUTO_N_POSES = 20
 DEFAULT_AUTO_MAX_ATTEMPTS = 60
 DEFAULT_AUTO_ROLL_RANGE_DEG = (-180.0, 180.0)
@@ -113,7 +117,10 @@ def _validate_sampling_attrs(sampling: dict) -> None:
     if not isinstance(look_at, (list, tuple)) or len(look_at) != 3:
         raise Exception(
             "'pose_sampling.look_at_point' must be a length-3 list [x, y, z] "
-            "(the chessboard's position in the robot base frame, in mm)."
+            "in the robot base frame, in mm: the target board's position for "
+            "eye-in-hand, or the static camera's position for eye-to-hand "
+            "(the tool +Z — and a board mounted facing along it — then aims "
+            "at the camera)."
         )
 
     roll = sampling.get("roll_range_deg")
@@ -162,6 +169,16 @@ def _parse_sampling_attrs(sampling: dict) -> dict:
         "seed": int(seed) if seed is not None else None,
         "roll_reference": roll_reference,
     }
+
+
+def _invert_se3(T: np.ndarray) -> np.ndarray:
+    """Invert a 4x4 rigid transform."""
+    R = T[:3, :3]
+    t = T[:3, 3]
+    out = np.eye(4)
+    out[:3, :3] = R.T
+    out[:3, 3] = -R.T @ t
+    return out
 
 
 class HandEyeCalibration(Generic, EasyResource):
@@ -256,6 +273,19 @@ class HandEyeCalibration(Generic, EasyResource):
             if not isinstance(body_name, str):
                 raise Exception(f"'{BODY_NAME_ATTR}' must be a string, got {type(body_name)}")
 
+        camera_frame_parent = attrs.get(CAMERA_FRAME_PARENT_ATTR)
+        if camera_frame_parent is not None:
+            if not isinstance(camera_frame_parent, str) or not camera_frame_parent:
+                raise Exception(
+                    f"'{CAMERA_FRAME_PARENT_ATTR}' must be a non-empty string, got {camera_frame_parent!r}"
+                )
+            if calib != CALIB_EYE_TO_HAND:
+                raise Exception(
+                    f"'{CAMERA_FRAME_PARENT_ATTR}' only applies to "
+                    f"{CALIB_ATTR}='{CALIB_EYE_TO_HAND}'; for eye-in-hand the "
+                    f"camera frame is always parented to the arm."
+                )
+
         motion = attrs.get(MOTION_ATTR)
         optional_deps = []
         if motion is not None:
@@ -317,6 +347,10 @@ class HandEyeCalibration(Generic, EasyResource):
             )
             self.poses.append(pose)
 
+        self.calibration_type = attrs.get(CALIB_ATTR, CALIB_EYE_IN_HAND)
+        self.camera_frame_parent = attrs.get(
+            CAMERA_FRAME_PARENT_ATTR, DEFAULT_CAMERA_FRAME_PARENT
+        )
         self.method = attrs.get(METHOD_ATTR, DEFAULT_METHOD)
         self.solver = attrs.get(SOLVER_ATTR, DEFAULT_SOLVER)
         self.sleep_seconds = attrs.get(SLEEP_ATTR, DEFAULT_SLEEP_SECONDS)
@@ -372,8 +406,21 @@ class HandEyeCalibration(Generic, EasyResource):
 
     async def _capture_opencv_measurement(self) -> dict:
         """Capture one hand-eye measurement at the current arm position for the
-        OpenCV solver path: gripper-in-base from the arm, target-in-camera from
+        OpenCV solver path: an arm pose from the arm, target-in-camera from
         the pose tracker. Raises if the tracker does not resolve exactly one body.
+
+        The arm pose is stored in the arrangement ``cv2.calibrateHandEye``
+        needs for the configured calibration type:
+
+        - eye-in-hand: gripper-in-base (R_gripper2base, t_gripper2base).
+        - eye-to-hand: the INVERSE, base-in-gripper. Feeding inverted arm
+          poses is OpenCV's documented recipe for a static camera watching a
+          gripper-held target; the solver output then comes back as
+          camera-in-base instead of camera-in-gripper.
+
+        The dict keys stay ``R_gripper2base``/``t_gripper2base`` either way
+        because they name the ``cv2.calibrateHandEye`` argument slots the
+        values are destined for, not the physical transform.
         """
         arm_pose = await self._read_arm_pose()
 
@@ -414,12 +461,21 @@ class HandEyeCalibration(Generic, EasyResource):
         )
         t_cam2target = np.array([[tracked_pose.x], [tracked_pose.y], [tracked_pose.z]], dtype=np.float64)
 
-        # TODO: Implement eye-to-hand. This should just be changing the
-        # order/in-frame values
+        # ``call_go_ov2mat`` returns parent-from-body directly (gripper-in-base
+        # for the arm pose here) — no compensating transpose needed since the
+        # RDK rotation fix. Eye-in-hand wants gripper-in-base as-is; eye-to-hand
+        # wants the full inverse, base-in-gripper.
+        if self.calibration_type == CALIB_EYE_TO_HAND:
+            R_arm = R_base2gripper.T
+            t_arm = -R_base2gripper.T @ t_base2gripper
+        else:
+            R_arm = R_base2gripper
+            t_arm = t_base2gripper
+
         return {
             "arm_pose": arm_pose,
-            "R_gripper2base": R_base2gripper,
-            "t_gripper2base": t_base2gripper,
+            "R_gripper2base": R_arm,
+            "t_gripper2base": t_arm,
             "R_target2cam": R_cam2target,
             "t_target2cam": t_cam2target,
         }
@@ -649,10 +705,17 @@ class HandEyeCalibration(Generic, EasyResource):
     ):
         """Evaluate per-pose calibration residuals to identify outlier measurements.
 
-        For a correct calibration, the target's pose expressed in the base frame
-        (T_target2base = T_gripper2base · T_cam2gripper · T_target2cam) should be
-        identical across every pose, since the target is physically fixed.
-        Deviations from the mean reveal which poses contributed bad measurements.
+        For a correct eye-in-hand calibration, the target's pose expressed in
+        the base frame (T_target2base = T_gripper2base · T_cam2gripper ·
+        T_target2cam) should be identical across every pose, since the target
+        is physically fixed. Deviations from the mean reveal which poses
+        contributed bad measurements.
+
+        The same arithmetic covers eye-to-hand when fed the values the solver
+        was fed: the arm-pose slots then hold base-in-gripper and the solved
+        transform is camera-in-base, so the product is target-in-GRIPPER —
+        which is the constant of that arrangement (the target is rigidly
+        held by the gripper). Either way: constant product, same outlier test.
 
         Returns a list of per-pose residual dicts plus summary stats.
         """
@@ -842,12 +905,25 @@ class HandEyeCalibration(Generic, EasyResource):
                             "+ robust branch selection"
                         )
 
+                        # For eye-to-hand, feed the solver chain INVERTED arm
+                        # poses (base-in-gripper). Under that substitution the
+                        # eye-in-hand math — including robust_bootstrap_handeye,
+                        # which has no eye-to-hand awareness of its own —
+                        # solves the eye-to-hand problem unchanged: X comes
+                        # back as camera-in-base (instead of camera-in-gripper)
+                        # and the refined Y as board-in-gripper (instead of
+                        # board-in-base).
+                        if self.calibration_type == CALIB_EYE_TO_HAND:
+                            T_arm_list = [_invert_se3(T) for T in T_be_list]
+                        else:
+                            T_arm_list = T_be_list
+
                         # Bootstrap with PnP-branch disambiguation (planar
                         # two-fold ambiguity) and station outlier rejection, so
                         # a few flipped or bad stations can't poison X_init and
                         # strand the refinement in the wrong basin.
                         boot = robust_bootstrap_handeye(
-                            T_be_list,
+                            T_arm_list,
                             [m["T_cw_candidates"] for m in measurements],
                             [m["pnp_reproj_errs"] for m in measurements],
                             method=getattr(cv2, self.method),
@@ -892,6 +968,7 @@ class HandEyeCalibration(Generic, EasyResource):
                         # board pose from the bootstrap consensus rather than
                         # blindly from station 0.
                         T_cw_list = [boot["selected_T_cw"][i] for i in kept]
+                        T_arm_list = [T_arm_list[i] for i in kept]
                         T_be_list = [T_be_list[i] for i in kept]
                         corners_2d_list = [corners_2d_list[i] for i in kept]
                         corners_3d_list = [corners_3d_list[i] for i in kept]
@@ -901,7 +978,7 @@ class HandEyeCalibration(Generic, EasyResource):
                             f"refining with reprojection-error solver on {len(kept)} station(s)..."
                         )
                         refinement = refine_handeye(
-                            T_be_list,
+                            T_arm_list,
                             corners_2d_list,
                             corners_3d_list,
                             K,
@@ -934,9 +1011,10 @@ class HandEyeCalibration(Generic, EasyResource):
 
                         # For the legacy per-pose residual summary, reconstruct the
                         # rotation/translation lists (kept stations, chain-consistent
-                        # PnP branches) in the convention that helper expects.
-                        R_gripper2base_list = [T[:3, :3] for T in T_be_list]
-                        t_gripper2base_list = [T[:3, 3].reshape(3, 1) for T in T_be_list]
+                        # PnP branches, arm poses in the same orientation actually fed
+                        # to the solver above) in the convention that helper expects.
+                        R_gripper2base_list = [T[:3, :3] for T in T_arm_list]
+                        t_gripper2base_list = [T[:3, 3].reshape(3, 1) for T in T_arm_list]
                         R_target2cam_list = [T[:3, :3] for T in T_cw_list]
                         t_target2cam_list = [T[:3, 3].reshape(3, 1) for T in T_cw_list]
 
@@ -968,26 +1046,43 @@ class HandEyeCalibration(Generic, EasyResource):
                             f"r_resid={r['rotation_residual_deg']:.3f}deg"
                         )
 
-                    # Convert OpenCV output to frame system format.
-                    # cv2.calibrateHandEye returns (R_cam2gripper, t_cam2gripper), i.e. the
-                    # camera's mounting orientation and position in the gripper frame — which
-                    # is exactly what the Viam frame system wants.
-                    t_gripper2cam = t_cam2gripper.reshape(3, 1)
+                    # Convert the solver output to frame system format. The
+                    # solved transform is the camera pose in its parent frame:
+                    #   eye-in-hand: camera-in-gripper, parent = the arm (the
+                    #     frame system attaches children to the arm's EE).
+                    #   eye-to-hand: camera-in-base (the inputs were inverted
+                    #     arm poses), parent = the static frame the arm base
+                    #     is mounted in — 'world' unless configured otherwise.
+                    # call_go_mat2ov takes the camera-in-parent rotation
+                    # directly (no compensating transpose, per the RDK
+                    # rotation fix).
+                    R_cam_in_parent = R_cam2gripper
+                    t_cam_in_parent = t_cam2gripper.reshape(3, 1)
+                    if self.calibration_type == CALIB_EYE_TO_HAND:
+                        parent_frame = self.camera_frame_parent
+                    else:
+                        parent_frame = self.arm.name
 
-                    orientation_result = call_go_mat2ov(R_cam2gripper)
+                    # Rotation matrix to orientation vector
+                    orientation_result = call_go_mat2ov(R_cam_in_parent)
                     if orientation_result is None:
                         raise Exception("failed to convert rotation matrix to orientation vector")
                     ox, oy, oz, theta = orientation_result
 
-                    x = float(t_gripper2cam[0][0])
-                    y = float(t_gripper2cam[1][0])
-                    z = float(t_gripper2cam[2][0])
+                    # Translation
+                    x = float(t_cam_in_parent[0][0])
+                    y = float(t_cam_in_parent[1][0])
+                    z = float(t_cam_in_parent[2][0])
 
                     viam_pose = Pose(x=x, y=y, z=z, o_x=ox, o_y=oy, o_z=oz, theta=theta)
 
-                    self.logger.info(f"calibration success: {viam_pose}")
+                    self.logger.info(
+                        f"calibration success ({self.calibration_type}, camera in "
+                        f"'{parent_frame}' frame): {viam_pose}"
+                    )
 
-                    # Format output to be frame system compatible
+                    # Format output to be frame system compatible: paste the
+                    # 'frame' dict into the camera component's frame config.
                     response = {
                         "frame": {
                             "translation": {
@@ -1004,13 +1099,14 @@ class HandEyeCalibration(Generic, EasyResource):
                                     "th": theta
                                 }
                             },
-                            "parent": self.arm.name
+                            "parent": parent_frame
                         },
                         "residuals": {
                             "summary": residual_summary,
                             "per_pose": per_pose_residuals,
                         },
                         "solver": self.solver,
+                        "calibration_type": self.calibration_type,
                     }
                     if refinement_info is not None:
                         response["refinement"] = refinement_info

--- a/src/models/hand_eye_calibration.py
+++ b/src/models/hand_eye_calibration.py
@@ -20,13 +20,13 @@ from utils.utils import call_go_ov2mat, call_go_mat2ov
 
 try:
     from diagnostics.pose_diversity import compute_pose_diversity
-    from solvers.reprojection_solver import refine_handeye
+    from solvers.reprojection_solver import _se3_inverse, refine_handeye
     from solvers.robust_init import robust_bootstrap_handeye
     from active_calibration.pose_sampler import generate_pose_set, sample_transform
 except ModuleNotFoundError:
     # when running as local module with run.sh
     from ..diagnostics.pose_diversity import compute_pose_diversity
-    from ..solvers.reprojection_solver import refine_handeye
+    from ..solvers.reprojection_solver import _se3_inverse, refine_handeye
     from ..solvers.robust_init import robust_bootstrap_handeye
     from ..active_calibration.pose_sampler import generate_pose_set, sample_transform
 
@@ -57,7 +57,6 @@ SOLVER_ATTR = "solver"
 USE_MOTION_SERVICE_FOR_POSES_ATTR = "use_motion_service_for_poses"
 POSE_SELECTION_ATTR = "pose_selection"
 POSE_SAMPLING_ATTR = "pose_sampling"
-CAMERA_FRAME_PARENT_ATTR = "camera_frame_parent"
 TARGET_ATTR = "target"
 
 # do_command keys a viam:opencv pose tracker exposes a raw observation under.
@@ -87,7 +86,6 @@ DEFAULT_METHOD = "CALIB_HAND_EYE_TSAI"
 DEFAULT_SOLVER = SOLVER_OPENCV
 DEFAULT_USE_MOTION_SERVICE_FOR_POSES = False
 DEFAULT_POSE_SELECTION = POSE_SELECTION_MANUAL
-DEFAULT_CAMERA_FRAME_PARENT = "world"
 DEFAULT_AUTO_N_POSES = 20
 DEFAULT_AUTO_MAX_ATTEMPTS = 60
 DEFAULT_AUTO_ROLL_RANGE_DEG = (-180.0, 180.0)
@@ -118,11 +116,8 @@ def _validate_sampling_attrs(sampling: dict) -> None:
     if not isinstance(look_at, (list, tuple)) or len(look_at) != 3:
         raise Exception(
             "'pose_sampling.look_at_point' must be a length-3 list [x, y, z] "
-            "in the robot base frame, in mm: the target board's position for "
-            "eye-in-hand, or the static camera's position for eye-to-hand "
-            "(the +Z of whatever frame is being aimed — the 'target' frame if "
-            "configured, otherwise the arm's own tool +Z with a board assumed "
-            "mounted facing along it — then aims at the camera)."
+            "in the robot base frame, in mm — the point the sampled frame's "
+            "+Z aims at. See README for eye-in-hand vs. eye-to-hand semantics."
         )
 
     roll = sampling.get("roll_range_deg")
@@ -171,16 +166,6 @@ def _parse_sampling_attrs(sampling: dict) -> dict:
         "seed": int(seed) if seed is not None else None,
         "roll_reference": roll_reference,
     }
-
-
-def _invert_se3(T: np.ndarray) -> np.ndarray:
-    """Invert a 4x4 rigid transform."""
-    R = T[:3, :3]
-    t = T[:3, 3]
-    out = np.eye(4)
-    out[:3, :3] = R.T
-    out[:3, 3] = -R.T @ t
-    return out
 
 
 class HandEyeCalibration(Generic, EasyResource):
@@ -275,19 +260,6 @@ class HandEyeCalibration(Generic, EasyResource):
             if not isinstance(body_name, str):
                 raise Exception(f"'{BODY_NAME_ATTR}' must be a string, got {type(body_name)}")
 
-        camera_frame_parent = attrs.get(CAMERA_FRAME_PARENT_ATTR)
-        if camera_frame_parent is not None:
-            if not isinstance(camera_frame_parent, str) or not camera_frame_parent:
-                raise Exception(
-                    f"'{CAMERA_FRAME_PARENT_ATTR}' must be a non-empty string, got {camera_frame_parent!r}"
-                )
-            if calib != CALIB_EYE_TO_HAND:
-                raise Exception(
-                    f"'{CAMERA_FRAME_PARENT_ATTR}' only applies to "
-                    f"{CALIB_ATTR}='{CALIB_EYE_TO_HAND}'; for eye-in-hand the "
-                    f"camera frame is always parented to the arm."
-                )
-
         target = attrs.get(TARGET_ATTR)
         if target is not None:
             if not isinstance(target, str) or not target:
@@ -302,9 +274,7 @@ class HandEyeCalibration(Generic, EasyResource):
         elif calib == CALIB_EYE_TO_HAND and pose_selection == POSE_SELECTION_AUTO:
             raise Exception(
                 f"'{TARGET_ATTR}' is required when {CALIB_ATTR}='{CALIB_EYE_TO_HAND}' and "
-                f"{POSE_SELECTION_ATTR}='{POSE_SELECTION_AUTO}': auto-mode sampling needs a "
-                f"frame, already configured in the machine's frame system as a child of the "
-                f"arm, to move and to model collision geometry for the held target."
+                f"{POSE_SELECTION_ATTR}='{POSE_SELECTION_AUTO}'."
             )
 
         motion = attrs.get(MOTION_ATTR)
@@ -369,9 +339,6 @@ class HandEyeCalibration(Generic, EasyResource):
             self.poses.append(pose)
 
         self.calibration_type = attrs.get(CALIB_ATTR, CALIB_EYE_IN_HAND)
-        self.camera_frame_parent = attrs.get(
-            CAMERA_FRAME_PARENT_ATTR, DEFAULT_CAMERA_FRAME_PARENT
-        )
         self.target = attrs.get(TARGET_ATTR)
         self.method = attrs.get(METHOD_ATTR, DEFAULT_METHOD)
         self.solver = attrs.get(SOLVER_ATTR, DEFAULT_SOLVER)
@@ -431,18 +398,12 @@ class HandEyeCalibration(Generic, EasyResource):
         OpenCV solver path: an arm pose from the arm, target-in-camera from
         the pose tracker. Raises if the tracker does not resolve exactly one body.
 
-        The arm pose is stored in the arrangement ``cv2.calibrateHandEye``
-        needs for the configured calibration type:
-
-        - eye-in-hand: gripper-in-base (R_gripper2base, t_gripper2base).
-        - eye-to-hand: the INVERSE, base-in-gripper. Feeding inverted arm
-          poses is OpenCV's documented recipe for a static camera watching a
-          gripper-held target; the solver output then comes back as
-          camera-in-base instead of camera-in-gripper.
-
-        The dict keys stay ``R_gripper2base``/``t_gripper2base`` either way
-        because they name the ``cv2.calibrateHandEye`` argument slots the
-        values are destined for, not the physical transform.
+        Eye-in-hand needs gripper-in-base; eye-to-hand needs the inverse
+        (base-in-gripper) — OpenCV's documented trick for a static camera,
+        which makes the solver return camera-in-base instead of
+        camera-in-gripper. The dict keys stay ``R_gripper2base``/
+        ``t_gripper2base`` either way since they name the
+        ``cv2.calibrateHandEye`` argument slots, not the physical transform.
         """
         arm_pose = await self._read_arm_pose()
 
@@ -483,10 +444,8 @@ class HandEyeCalibration(Generic, EasyResource):
         )
         t_cam2target = np.array([[tracked_pose.x], [tracked_pose.y], [tracked_pose.z]], dtype=np.float64)
 
-        # ``call_go_ov2mat`` returns parent-from-body directly (gripper-in-base
-        # for the arm pose here) — no compensating transpose needed since the
-        # RDK rotation fix. Eye-in-hand wants gripper-in-base as-is; eye-to-hand
-        # wants the full inverse, base-in-gripper.
+        # call_go_ov2mat returns gripper-in-base directly (no transpose needed
+        # since the RDK rotation fix); eye-to-hand needs the inverse.
         if self.calibration_type == CALIB_EYE_TO_HAND:
             R_arm = R_base2gripper.T
             t_arm = -R_base2gripper.T @ t_base2gripper
@@ -691,13 +650,8 @@ class HandEyeCalibration(Generic, EasyResource):
             position_data: Either a list of joint positions (radians) or a Pose object
             position_index: Index of the current position
             total_positions: Total number of positions
-            component_name: Which frame to command the motion service to move to
-                ``position_data`` (defaults to the arm itself). Passing a
-                different, already-configured frame name here — e.g. one
-                representing a target rigidly held by the gripper — lets the
-                motion service resolve the required arm motion itself and
-                avoid collisions using that frame's own geometry, without
-                this module needing to know the mount offset or geometry.
+            component_name: Which frame to command the motion service to move
+                to ``position_data`` (defaults to the arm itself).
         """
         self.logger.debug(f"Moving to position {position_index+1}/{total_positions}")
 
@@ -946,16 +900,11 @@ class HandEyeCalibration(Generic, EasyResource):
                             "+ robust branch selection"
                         )
 
-                        # For eye-to-hand, feed the solver chain INVERTED arm
-                        # poses (base-in-gripper). Under that substitution the
-                        # eye-in-hand math — including robust_bootstrap_handeye,
-                        # which has no eye-to-hand awareness of its own —
-                        # solves the eye-to-hand problem unchanged: X comes
-                        # back as camera-in-base (instead of camera-in-gripper)
-                        # and the refined Y as board-in-gripper (instead of
-                        # board-in-base).
+                        # Same eye-to-hand inversion as _capture_opencv_measurement:
+                        # robust_bootstrap_handeye has no eye-to-hand awareness of
+                        # its own, so it's applied here to the arm poses instead.
                         if self.calibration_type == CALIB_EYE_TO_HAND:
-                            T_arm_list = [_invert_se3(T) for T in T_be_list]
+                            T_arm_list = [_se3_inverse(T) for T in T_be_list]
                         else:
                             T_arm_list = T_be_list
 
@@ -1087,30 +1036,20 @@ class HandEyeCalibration(Generic, EasyResource):
                             f"r_resid={r['rotation_residual_deg']:.3f}deg"
                         )
 
-                    # Convert the solver output to frame system format. The
-                    # solved transform is the camera pose in its parent frame:
-                    #   eye-in-hand: camera-in-gripper, parent = the arm (the
-                    #     frame system attaches children to the arm's EE).
-                    #   eye-to-hand: camera-in-base (the inputs were inverted
-                    #     arm poses), parent = the static frame the arm base
-                    #     is mounted in — 'world' unless configured otherwise.
-                    # call_go_mat2ov takes the camera-in-parent rotation
-                    # directly (no compensating transpose, per the RDK
-                    # rotation fix).
+                    # Solved transform is the camera pose in its parent frame:
+                    # eye-in-hand's parent is the arm; eye-to-hand's is "world".
                     R_cam_in_parent = R_cam2gripper
                     t_cam_in_parent = t_cam2gripper.reshape(3, 1)
                     if self.calibration_type == CALIB_EYE_TO_HAND:
-                        parent_frame = self.camera_frame_parent
+                        parent_frame = "world"
                     else:
                         parent_frame = self.arm.name
 
-                    # Rotation matrix to orientation vector
                     orientation_result = call_go_mat2ov(R_cam_in_parent)
                     if orientation_result is None:
                         raise Exception("failed to convert rotation matrix to orientation vector")
                     ox, oy, oz, theta = orientation_result
 
-                    # Translation
                     x = float(t_cam_in_parent[0][0])
                     y = float(t_cam_in_parent[1][0])
                     z = float(t_cam_in_parent[2][0])

--- a/src/models/hand_eye_calibration.py
+++ b/src/models/hand_eye_calibration.py
@@ -58,6 +58,7 @@ USE_MOTION_SERVICE_FOR_POSES_ATTR = "use_motion_service_for_poses"
 POSE_SELECTION_ATTR = "pose_selection"
 POSE_SAMPLING_ATTR = "pose_sampling"
 CAMERA_FRAME_PARENT_ATTR = "camera_frame_parent"
+TARGET_ATTR = "target"
 
 # do_command keys a viam:opencv pose tracker exposes a raw observation under.
 # A chessboard reports the full grid every frame; a ChArUco board may report a
@@ -119,8 +120,9 @@ def _validate_sampling_attrs(sampling: dict) -> None:
             "'pose_sampling.look_at_point' must be a length-3 list [x, y, z] "
             "in the robot base frame, in mm: the target board's position for "
             "eye-in-hand, or the static camera's position for eye-to-hand "
-            "(the tool +Z — and a board mounted facing along it — then aims "
-            "at the camera)."
+            "(the +Z of whatever frame is being aimed — the 'target' frame if "
+            "configured, otherwise the arm's own tool +Z with a board assumed "
+            "mounted facing along it — then aims at the camera)."
         )
 
     roll = sampling.get("roll_range_deg")
@@ -286,6 +288,25 @@ class HandEyeCalibration(Generic, EasyResource):
                     f"camera frame is always parented to the arm."
                 )
 
+        target = attrs.get(TARGET_ATTR)
+        if target is not None:
+            if not isinstance(target, str) or not target:
+                raise Exception(
+                    f"'{TARGET_ATTR}' must be a non-empty string, got {target!r}"
+                )
+            if calib != CALIB_EYE_TO_HAND:
+                raise Exception(
+                    f"'{TARGET_ATTR}' only applies to {CALIB_ATTR}='{CALIB_EYE_TO_HAND}'; "
+                    f"it names the frame that auto-mode sampling moves in place of the arm."
+                )
+        elif calib == CALIB_EYE_TO_HAND and pose_selection == POSE_SELECTION_AUTO:
+            raise Exception(
+                f"'{TARGET_ATTR}' is required when {CALIB_ATTR}='{CALIB_EYE_TO_HAND}' and "
+                f"{POSE_SELECTION_ATTR}='{POSE_SELECTION_AUTO}': auto-mode sampling needs a "
+                f"frame, already configured in the machine's frame system as a child of the "
+                f"arm, to move and to model collision geometry for the held target."
+            )
+
         motion = attrs.get(MOTION_ATTR)
         optional_deps = []
         if motion is not None:
@@ -351,6 +372,7 @@ class HandEyeCalibration(Generic, EasyResource):
         self.camera_frame_parent = attrs.get(
             CAMERA_FRAME_PARENT_ATTR, DEFAULT_CAMERA_FRAME_PARENT
         )
+        self.target = attrs.get(TARGET_ATTR)
         self.method = attrs.get(METHOD_ATTR, DEFAULT_METHOD)
         self.solver = attrs.get(SOLVER_ATTR, DEFAULT_SOLVER)
         self.sleep_seconds = attrs.get(SLEEP_ATTR, DEFAULT_SLEEP_SECONDS)
@@ -583,6 +605,11 @@ class HandEyeCalibration(Generic, EasyResource):
             raise Exception(
                 f"{POSE_SELECTION_ATTR}='{POSE_SELECTION_AUTO}' requires a motion service"
             )
+        if self.calibration_type == CALIB_EYE_TO_HAND and not self.target:
+            raise Exception(
+                f"{CALIB_ATTR}='{CALIB_EYE_TO_HAND}' with "
+                f"{POSE_SELECTION_ATTR}='{POSE_SELECTION_AUTO}' requires '{TARGET_ATTR}'"
+            )
 
         rng = np.random.default_rng(sampling["seed"])
         n_target = sampling["n_poses"]
@@ -606,9 +633,13 @@ class HandEyeCalibration(Generic, EasyResource):
                 self.logger.warning(f"attempt {attempts}: sampler error: {e}")
                 continue
 
+            # target is required (and validated non-empty) above whenever
+            # calibration_type is eye-to-hand, so this is always the target
+            # frame for eye-to-hand and always the arm for eye-in-hand.
+            move_component = self.target if self.calibration_type == CALIB_EYE_TO_HAND else None
             try:
                 await self._move_arm_to_position(
-                    candidate, len(achieved), n_target
+                    candidate, len(achieved), n_target, component_name=move_component
                 )
                 await asyncio.sleep(self.sleep_seconds)
             except Exception as e:
@@ -651,29 +682,39 @@ class HandEyeCalibration(Generic, EasyResource):
 
         return achieved, measurements
 
-    async def _move_arm_to_position(self, position_data, position_index, total_positions):
+    async def _move_arm_to_position(
+        self, position_data, position_index, total_positions, component_name: Optional[str] = None
+    ):
         """Move arm to specified position using joint control, direct pose control, or motion planning.
 
         Args:
             position_data: Either a list of joint positions (radians) or a Pose object
             position_index: Index of the current position
             total_positions: Total number of positions
+            component_name: Which frame to command the motion service to move to
+                ``position_data`` (defaults to the arm itself). Passing a
+                different, already-configured frame name here — e.g. one
+                representing a target rigidly held by the gripper — lets the
+                motion service resolve the required arm motion itself and
+                avoid collisions using that frame's own geometry, without
+                this module needing to know the mount offset or geometry.
         """
         self.logger.debug(f"Moving to position {position_index+1}/{total_positions}")
 
         is_pose = isinstance(position_data, Pose)
 
         if self.motion is not None and is_pose:
+            move_component = component_name or self.arm.name
             # hack to get the arm to move relative to the base of the arm, not the end TCP
             pif = PoseInFrame(reference_frame=self.arm.name + "_origin", pose=position_data)
 
             success = await self.motion.move(
-                component_name=self.arm.name,
+                component_name=move_component,
                 destination=pif,
             )
             if not success:
                 raise Exception(f"Could not move to pose {position_index+1}/{total_positions}")
-            self.logger.debug(f"Moved arm to pose: {pif} using motion planning")
+            self.logger.debug(f"Moved {move_component} to pose: {pif} using motion planning")
         elif is_pose:
             # Direct pose control using arm.move_to_position
             try:

--- a/src/models/hand_eye_calibration.py
+++ b/src/models/hand_eye_calibration.py
@@ -959,7 +959,6 @@ class HandEyeCalibration(Generic, EasyResource):
                         # blindly from station 0.
                         T_cw_list = [boot["selected_T_cw"][i] for i in kept]
                         T_arm_list = [T_arm_list[i] for i in kept]
-                        T_be_list = [T_be_list[i] for i in kept]
                         corners_2d_list = [corners_2d_list[i] for i in kept]
                         corners_3d_list = [corners_3d_list[i] for i in kept]
                         station_numbers = [i + 1 for i in kept]
@@ -1037,11 +1036,11 @@ class HandEyeCalibration(Generic, EasyResource):
                         )
 
                     # Solved transform is the camera pose in its parent frame:
-                    # eye-in-hand's parent is the arm; eye-to-hand's is "world".
+                    # eye-in-hand's parent is the arm; eye-to-hand's is arm's base frame
                     R_cam_in_parent = R_cam2gripper
                     t_cam_in_parent = t_cam2gripper.reshape(3, 1)
                     if self.calibration_type == CALIB_EYE_TO_HAND:
-                        parent_frame = "world"
+                        parent_frame = self.arm.name + "_origin"
                     else:
                         parent_frame = self.arm.name
 

--- a/tests/models/test_hand_eye_calibration_target.py
+++ b/tests/models/test_hand_eye_calibration_target.py
@@ -1,0 +1,177 @@
+"""Tests for the ``target`` attribute added to eye-to-hand auto-mode sampling.
+
+Covers two things: that ``validate_config`` scopes ``target`` to eye-to-hand,
+and that ``_sample_and_move_loop`` commands the motion service to move the
+``target`` frame instead of the arm when it's configured. The service is
+built with ``object.__new__`` and relevant attributes set directly, following
+the pattern in ``test_camera_calibration.py`` — no full Viam resource
+lifecycle needed.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+from google.protobuf.struct_pb2 import Struct
+from viam.proto.app.robot import ComponentConfig
+from viam.proto.common import Pose
+
+import models.hand_eye_calibration as hec
+from models.hand_eye_calibration import (
+    CALIB_EYE_IN_HAND,
+    CALIB_EYE_TO_HAND,
+    HandEyeCalibration,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_go_mat2ov(monkeypatch):
+    # _transform_to_viam_pose shells out to the compiled go_utils binary for
+    # rotation-matrix -> orientation-vector conversion, which isn't built in
+    # this environment. These tests only care about which frame gets moved,
+    # not the orientation math (covered elsewhere), so stub it out.
+    monkeypatch.setattr(hec, "call_go_mat2ov", lambda R: (0.0, 0.0, 1.0, 0.0))
+
+
+def _config(attrs: dict) -> ComponentConfig:
+    struct = Struct()
+    struct.update(attrs)
+    return ComponentConfig(attributes=struct)
+
+
+_BASE_ATTRS = {
+    "arm_name": "my_arm",
+    "pose_tracker": "charuco_tracker",
+    "motion": "motion",
+    "method": "CALIB_HAND_EYE_TSAI",
+    "pose_selection": "auto",
+    "pose_sampling": {
+        "workspace_bounds": {
+            "x": {"min": 200, "max": 450},
+            "y": {"min": -150, "max": 150},
+            "z": {"min": 200, "max": 450},
+        },
+        "look_at_point": [700, 0, 300],
+        "n_poses": 5,
+    },
+}
+
+
+def test_validate_config_rejects_target_for_eye_in_hand():
+    attrs = {**_BASE_ATTRS, "calibration_type": CALIB_EYE_IN_HAND, "target": "charuco_target"}
+    with pytest.raises(Exception, match="target"):
+        HandEyeCalibration.validate_config(_config(attrs))
+
+
+def test_validate_config_accepts_target_for_eye_to_hand():
+    attrs = {**_BASE_ATTRS, "calibration_type": CALIB_EYE_TO_HAND, "target": "charuco_target"}
+    required, _optional = HandEyeCalibration.validate_config(_config(attrs))
+    assert "my_arm" in required
+    assert "charuco_tracker" in required
+
+
+def test_validate_config_requires_target_for_eye_to_hand_auto():
+    attrs = {**_BASE_ATTRS, "calibration_type": CALIB_EYE_TO_HAND}
+    assert "target" not in attrs
+    with pytest.raises(Exception, match="target"):
+        HandEyeCalibration.validate_config(_config(attrs))
+
+
+def test_validate_config_does_not_require_target_for_eye_to_hand_manual():
+    attrs = {
+        **_BASE_ATTRS,
+        "calibration_type": CALIB_EYE_TO_HAND,
+        "pose_selection": "manual",
+        "poses": [{"x": 300, "y": 0, "z": 300, "o_x": 0, "o_y": 0, "o_z": 1, "theta": 0}],
+    }
+    attrs.pop("pose_sampling")
+    required, _optional = HandEyeCalibration.validate_config(_config(attrs))
+    assert "my_arm" in required
+
+
+def _service(calibration_type: str, target: str | None):
+    """Build a HandEyeCalibration with just enough state for
+    _sample_and_move_loop / _move_arm_to_position to run, mocking the motion
+    service and arm. ``_capture_measurement`` is mocked directly rather than
+    exercised for real, since the real path shells out to the compiled
+    go_utils binary (not built in this environment) — out of scope for a
+    test that's only checking which frame gets moved."""
+    svc = object.__new__(HandEyeCalibration)
+    svc.logger = __import__("logging").getLogger("test")
+
+    class _Arm:
+        name = "my_arm"
+
+        async def get_end_position(self):
+            return Pose(x=300, y=0, z=300, o_x=0, o_y=0, o_z=1, theta=0)
+
+        async def is_moving(self):
+            return False
+
+    svc.arm = _Arm()
+    svc.arm_name = "my_arm"
+
+    svc.motion = AsyncMock()
+    svc.motion.move = AsyncMock(return_value=True)
+
+    svc._capture_measurement = AsyncMock(
+        return_value={"arm_pose": Pose(x=300, y=0, z=300, o_x=0, o_y=0, o_z=1, theta=0)}
+    )
+
+    svc.calibration_type = calibration_type
+    svc.target = target
+    svc.solver = "opencv"
+    svc.sleep_seconds = 0
+    svc.use_motion_service_for_poses = False
+
+    return svc
+
+
+_SAMPLING = {
+    "workspace_bounds": {
+        "x": {"min": 200, "max": 450},
+        "y": {"min": -150, "max": 150},
+        "z": {"min": 200, "max": 450},
+    },
+    "look_at_point": [700, 0, 300],
+    "roll_range_rad": (-np.pi, np.pi),
+    "n_poses": 3,
+    "max_attempts": 10,
+    "seed": 0,
+    "roll_reference": None,
+}
+
+
+def test_auto_sampling_moves_target_frame_when_configured():
+    svc = _service(CALIB_EYE_TO_HAND, target="charuco_target")
+
+    asyncio.run(svc._sample_and_move_loop(_SAMPLING))
+
+    svc.motion.move.assert_awaited()
+    _, kwargs = svc.motion.move.call_args
+    assert kwargs["component_name"] == "charuco_target"
+
+
+def test_auto_sampling_raises_when_eye_to_hand_without_target():
+    # target is required for eye-to-hand auto mode; validate_config already
+    # rejects this combination, but _sample_and_move_loop guards it too
+    # (matching the existing defensive check for a missing motion service).
+    svc = _service(CALIB_EYE_TO_HAND, target=None)
+
+    with pytest.raises(Exception, match="target"):
+        asyncio.run(svc._sample_and_move_loop(_SAMPLING))
+
+    svc.motion.move.assert_not_awaited()
+
+
+def test_auto_sampling_moves_arm_when_eye_in_hand_even_with_target_set():
+    # target only applies to eye-to-hand; validate_config would reject this
+    # combination, but the move loop itself should not use it either.
+    svc = _service(CALIB_EYE_IN_HAND, target="charuco_target")
+
+    asyncio.run(svc._sample_and_move_loop(_SAMPLING))
+
+    svc.motion.move.assert_awaited()
+    _, kwargs = svc.motion.move.call_args
+    assert kwargs["component_name"] == "my_arm"

--- a/tests/solvers/test_eye_to_hand.py
+++ b/tests/solvers/test_eye_to_hand.py
@@ -1,0 +1,262 @@
+"""Eye-to-hand round-trip tests for the hand-eye calibration math.
+
+Scenario: a static camera watches a ChArUco/chessboard target rigidly held in
+the gripper. The service solves this by feeding INVERTED arm poses
+(base-in-gripper) into the same eye-in-hand machinery; the solved X is then
+camera-in-base and the refined Y is board-in-gripper.
+
+These tests build a synthetic ground-truth scene (known camera-in-base and
+board-in-gripper), generate stations and projected corners, and verify that
+the exact call sequence `run_calibration` performs — cv2.calibrateHandEye on
+inverted poses to bootstrap, then refine_handeye on inverted poses — recovers
+the ground truth. Partial per-station corner subsets mimic gripper occlusion.
+"""
+
+import cv2
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from solvers.reprojection_solver import _se3_inverse, refine_handeye
+
+
+def _se3(R, t):
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = t
+    return T
+
+
+def _euler_xyz_se3(rx_deg, ry_deg, rz_deg, t):
+    R = Rotation.from_euler("xyz", [rx_deg, ry_deg, rz_deg], degrees=True).as_matrix()
+    return _se3(R, np.asarray(t, dtype=np.float64))
+
+
+def _board_corners(rows=5, cols=7, square_mm=25.0):
+    pts = np.zeros((rows * cols, 3), dtype=np.float64)
+    pts[:, :2] = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2)
+    pts *= square_mm
+    return pts
+
+
+def _camera_intrinsics():
+    K = np.array(
+        [
+            [600.0, 0.0, 320.0],
+            [0.0, 600.0, 240.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    dist = np.zeros(5)
+    return K, dist
+
+
+def _camera_in_base():
+    """Camera on a tripod at [700, 0, 300] mm, optical axis looking along
+    base -X toward the workspace. Columns are the camera axes in base:
+    x_cam = +Y_base (image right), y_cam = -Z_base (image down, OpenCV
+    convention), z_cam = -X_base (view direction). Right-handed:
+    x_cam × y_cam = Y × -Z = -X = z_cam."""
+    R_bc = np.array(
+        [
+            [0.0, 0.0, -1.0],
+            [1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    return _se3(R_bc, np.array([700.0, 0.0, 300.0]))
+
+
+def _project_board(corners_3d, T_c_board, K, dist):
+    rvec, _ = cv2.Rodrigues(T_c_board[:3, :3])
+    proj, _ = cv2.projectPoints(corners_3d, rvec, T_c_board[:3, 3].reshape(3, 1), K, dist)
+    return proj.reshape(-1, 2)
+
+
+def _build_eye_to_hand_dataset(noise_pixels=0.0, seed=0):
+    """Returns dict with T_be_list (gripper-in-base), corners, intrinsics,
+    T_cw_list (board-in-camera PnP poses), and ground truth T_bc_true
+    (camera-in-base) / T_eboard_true (board-in-gripper)."""
+    rng = np.random.default_rng(seed)
+    K, dist = _camera_intrinsics()
+    corners_3d = _board_corners()
+
+    T_bc_true = _camera_in_base()
+    # Board bolted 60 mm past the flange, slightly askew — exactly the
+    # unknown, constant grasp transform of a gripper-held board. The ~180°
+    # y-rotation puts the printed face (board -Z side) toward the camera:
+    # OpenCV's planar-PnP convention has the board +Z pointing away from
+    # the viewer, and IPPE only represents poses on that side.
+    T_eboard_true = _euler_xyz_se3(3.0, 178.0, 8.0, [-75.0, -50.0, 60.0])
+
+    # Stations: gripper near [300, 0, 300] with tool +Z aimed roughly along
+    # base +X so the held board faces the camera, with orientation diversity
+    # about all three axes (rotation-axis diversity is what conditions the
+    # hand-eye problem).
+    rotation_specs = [
+        (0.0, 90.0, 0.0),
+        (30.0, 70.0, 10.0),
+        (-28.0, 105.0, -20.0),
+        (15.0, 120.0, 35.0),
+        (-20.0, 65.0, 40.0),
+        (35.0, 95.0, -30.0),
+        (-15.0, 75.0, -45.0),
+        (25.0, 110.0, 55.0),
+    ]
+    translation_specs = [
+        [300.0, 0.0, 300.0],
+        [320.0, 30.0, 280.0],
+        [280.0, -30.0, 320.0],
+        [310.0, 20.0, 340.0],
+        [290.0, -20.0, 260.0],
+        [330.0, 10.0, 310.0],
+        [270.0, 40.0, 290.0],
+        [305.0, -40.0, 330.0],
+    ]
+
+    T_be_list = []
+    corners_2d_list = []
+    T_cw_list = []
+    T_cb_true = _se3_inverse(T_bc_true)
+    for rs, ts in zip(rotation_specs, translation_specs):
+        T_be = _euler_xyz_se3(*rs, ts)
+        T_be_list.append(T_be)
+
+        # Board-in-camera: T_c_board = T_cb · T_be · T_eboard
+        T_c_board = T_cb_true @ T_be @ T_eboard_true
+        # Every corner must be in front of the static camera.
+        pts_cam = (T_c_board[:3, :3] @ corners_3d.T).T + T_c_board[:3, 3]
+        assert np.all(pts_cam[:, 2] > 0), "synthetic geometry: board behind camera"
+
+        u = _project_board(corners_3d, T_c_board, K, dist)
+        if noise_pixels > 0:
+            u = u + rng.normal(0, noise_pixels, size=u.shape)
+        corners_2d_list.append(u)
+
+        # Per-station PnP exactly as the charuco tracker does it: IPPE with
+        # the lowest-reprojection-error branch (planar two-fold ambiguity).
+        n_sol, rvecs, tvecs, _errs = cv2.solvePnPGeneric(
+            corners_3d,
+            u.reshape(-1, 1, 2).astype(np.float64),
+            K,
+            dist,
+            flags=cv2.SOLVEPNP_IPPE,
+        )
+        assert n_sol >= 1
+        R_cw, _ = cv2.Rodrigues(rvecs[0])
+        T_cw_list.append(_se3(R_cw, tvecs[0].reshape(3)))
+
+    return {
+        "T_be_list": T_be_list,
+        "corners_2d_list": corners_2d_list,
+        "corners_3d": corners_3d,
+        "K": K,
+        "dist": dist,
+        "T_bc_true": T_bc_true,
+        "T_eboard_true": T_eboard_true,
+        "T_cw_list": T_cw_list,
+    }
+
+
+def _se3_diff(T_a, T_b):
+    delta_R = T_a[:3, :3] @ T_b[:3, :3].T
+    cos_angle = np.clip((np.trace(delta_R) - 1.0) / 2.0, -1.0, 1.0)
+    rot_deg = float(np.degrees(np.arccos(cos_angle)))
+    trans_mm = float(np.linalg.norm(T_a[:3, 3] - T_b[:3, 3]))
+    return trans_mm, rot_deg
+
+
+def _bootstrap_camera_in_base(data):
+    """The service's opencv-solver path for eye-to-hand: calibrateHandEye on
+    inverted arm poses. Output is camera-in-base."""
+    T_arm_list = [_se3_inverse(T) for T in data["T_be_list"]]
+    R_g2b = [T[:3, :3] for T in T_arm_list]
+    t_g2b = [T[:3, 3].reshape(3, 1) for T in T_arm_list]
+    R_t2c = [T[:3, :3] for T in data["T_cw_list"]]
+    t_t2c = [T[:3, 3].reshape(3, 1) for T in data["T_cw_list"]]
+    R, t = cv2.calibrateHandEye(
+        R_g2b, t_g2b, R_t2c, t_t2c, method=cv2.CALIB_HAND_EYE_TSAI
+    )
+    return _se3(R, t.flatten()), T_arm_list
+
+
+# ---- tests ----
+
+
+def test_opencv_bootstrap_recovers_camera_in_base():
+    data = _build_eye_to_hand_dataset(noise_pixels=0.0)
+    X_boot, _ = _bootstrap_camera_in_base(data)
+    trans_err, rot_err = _se3_diff(X_boot, data["T_bc_true"])
+    assert trans_err < 0.5, f"translation error {trans_err:.4f} mm too high"
+    assert rot_err < 0.05, f"rotation error {rot_err:.4f} deg too high"
+
+
+def test_refinement_recovers_camera_in_base_and_board_in_gripper():
+    data = _build_eye_to_hand_dataset(noise_pixels=0.0)
+    X_boot, T_arm_list = _bootstrap_camera_in_base(data)
+    out = refine_handeye(
+        T_arm_list,
+        data["corners_2d_list"],
+        data["corners_3d"],
+        data["K"],
+        data["dist"],
+        X_init=X_boot,
+        T_cw_list=data["T_cw_list"],
+    )
+    assert out["success"]
+    assert out["rmse_pixels"] < 0.5
+
+    trans_err, rot_err = _se3_diff(out["X_refined"], data["T_bc_true"])
+    assert trans_err < 0.1, f"camera-in-base translation error {trans_err:.4f} mm"
+    assert rot_err < 0.05, f"camera-in-base rotation error {rot_err:.4f} deg"
+
+    trans_err, rot_err = _se3_diff(out["Y_refined"], data["T_eboard_true"])
+    assert trans_err < 0.1, f"board-in-gripper translation error {trans_err:.4f} mm"
+    assert rot_err < 0.05, f"board-in-gripper rotation error {rot_err:.4f} deg"
+
+
+def test_partial_views_gripper_occlusion():
+    """Each station sees a different subset of corners, as when the gripper
+    hides part of the ChArUco board. Recovery should still hold."""
+    data = _build_eye_to_hand_dataset(noise_pixels=0.1, seed=3)
+    rng = np.random.default_rng(7)
+
+    n_corners = data["corners_3d"].shape[0]
+    corners_2d_subsets = []
+    corners_3d_subsets = []
+    for u in data["corners_2d_list"]:
+        keep = rng.choice(n_corners, size=int(n_corners * 0.6), replace=False)
+        keep.sort()
+        corners_2d_subsets.append(u[keep])
+        corners_3d_subsets.append(data["corners_3d"][keep])
+
+    X_boot, T_arm_list = _bootstrap_camera_in_base(data)
+    out = refine_handeye(
+        T_arm_list,
+        corners_2d_subsets,
+        corners_3d_subsets,
+        data["K"],
+        data["dist"],
+        X_init=X_boot,
+        T_cw_list=data["T_cw_list"],
+    )
+    assert out["success"]
+
+    trans_err, rot_err = _se3_diff(out["X_refined"], data["T_bc_true"])
+    assert trans_err < 1.0, f"camera-in-base translation error {trans_err:.4f} mm"
+    assert rot_err < 0.1, f"camera-in-base rotation error {rot_err:.4f} deg"
+
+
+def test_target_in_gripper_invariant():
+    """The residual diagnostic's eye-to-hand invariant: with inverted arm
+    poses and the solved camera-in-base, the product in
+    _compute_per_pose_residuals is target-in-gripper — constant across
+    stations, equal to the true grasp transform."""
+    data = _build_eye_to_hand_dataset(noise_pixels=0.0)
+    X_boot, T_arm_list = _bootstrap_camera_in_base(data)
+
+    for T_arm, T_cw in zip(T_arm_list, data["T_cw_list"]):
+        # Mirrors R_g2b @ R_c2g @ R_t2c with the eye-to-hand substitution.
+        T_target_in_gripper = T_arm @ X_boot @ T_cw
+        trans_err, rot_err = _se3_diff(T_target_in_gripper, data["T_eboard_true"])
+        assert trans_err < 0.5
+        assert rot_err < 0.05


### PR DESCRIPTION
Add support of opencv's default hand-to-eye calibration.

In both manual and auto mode, the calibration board needs to be affixed to the arm in a way that can be viewable to the camera. I tested with a charuco tag held in the gripper with an overhead realsense. 

Manual mode should function the same as hand-in-eye calibration where the user defines poses with the calibration board in sight of the camera.

For auto mode, the user will have to define a "target" frame/obstacle that corresponds roughly to the location of the calibration board relative to the arm. The "look-at-point" now becomes the location of the camera. Otherwise, the calibration functions in the same way as the hand-in-eye one does, i.e. it uses motion planning to generate poses within the bounding box that point the target frame roughly at the look-at-point. 

My thought process for using adding the "target" was:
1. It forces the user to create a collision box for the board whenever doing the auto calibration. 
2. We get the frame of the tag for free which makes it easier to do the calculations to get the board in frame. 
3. This will extend cleanly to any methodology that would involve affixing a calibration tag to the arm, e.g. taping an april tag to the side of the gripper. 

