### PR TITLE
Use the headless OpenCV wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ hpack==4.1.0
 hyperframe==6.1.0
 multidict==6.6.4
 numpy==2.2.6
-opencv-python==4.12.0.88
+opencv-python-headless==4.12.0.88
 scipy>=1.10
 pillow==11.3.0
 protobuf==5.29.5


### PR DESCRIPTION
## Summary

`opencv-python` is the GUI build of OpenCV: importing `cv2` loads Qt, which links `libGL.so.1`, `libX11.so.6`, `libxcb.so.1`, `libICE.so.6`, `libSM.so.6`, `libXext.so.6`, `libglib-2.0.so.0` and `libgthread-2.0.so.0`. A desktop image happens to have those; a server or minimal container image does not, so on a freshly provisioned machine the module dies at import with `libGL.so.1: cannot open shared object file`. That then surfaces as a `model not registered` cascade across every resource depending on this module, which reads like a config error rather than a missing `.so`.

This module never opens a window — there is no display on a machine to draw on. `opencv-python-headless` is the same `cv2` API at the same version without the Qt linkage, which leaves `libz.so.1` as the only external library `cv2` needs, and that is part of every Linux base system. **Nothing has to be installed on the host.**

> **Alternative to #40.** That PR adds a ~400-line `first_run.sh` that installs the eight libraries at module-install time. This is the one-line fix for the same problem. They are mutually exclusive — merging this one makes #40 unnecessary for this repo. Picking between them is a maintainer call; I opened both so the choice is concrete.

## Testing

Installed the full `requirements.txt` in `python:3.11-slim`, which has no `libGL`:

- `cv2`, `numpy`, `scipy` and `PIL` all import; `cv2.__version__` is `4.12.0`
- `pip list` shows `opencv-python-headless` and no `opencv-python`
- for contrast, the same container with `opencv-python` installed fails on `import cv2` with `ImportError: libGL.so.1`

No source change was needed: the repo contains no calls to `cv2.imshow`, `waitKey`, `namedWindow`, `destroyWindow`, `createTrackbar`, `selectROI`, `setMouseCallback` or the other GUI entry points the headless wheel omits.

The library list above is not guesswork — it is the set of `DT_NEEDED` entries across the wheels' ELF objects that the wheel does not itself vendor, computed for both `manylinux2014_x86_64` and `manylinux2014_aarch64` (identical on both).

<details>
<summary>Claude Code prompts used</summary>

- "Can you open the PRs using opencv-python-headless ?"

</details>
